### PR TITLE
run admin.initializeApp globally

### DIFF
--- a/functions/src/backfillToTypesenseFromFirestore.js
+++ b/functions/src/backfillToTypesenseFromFirestore.js
@@ -4,6 +4,10 @@ const config = require("./config");
 const typesense = require("./typesenseClient");
 const utils = require("./utils");
 
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+
 const validateBackfillRun = (snapshot) => {
   if (![true, "true"].includes(snapshot.after.get("trigger"))) {
     functions.logger.error(
@@ -25,10 +29,6 @@ module.exports = functions.handler.firestore.document
       if (!validateBackfillRun(snapshot)) {
         return false;
       }
-
-      admin.initializeApp({
-        credential: admin.credential.applicationDefault(),
-      });
 
       const querySnapshot =
         await admin.firestore().collection(config.firestoreCollectionPath).get();


### PR DESCRIPTION
Run admin.initializeApp() on load to prevent multiple invocations in the event user runs backfill multiple times while a function instance is still active.

## Change Summary
Executes admin.initializeApp() only once per function instance to avoid multiple invocation error. 


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
