### PR TITLE
Log Typesense API call error and format

### DIFF
--- a/functions/src/backfillToTypesenseFromFirestore.js
+++ b/functions/src/backfillToTypesenseFromFirestore.js
@@ -59,7 +59,7 @@ module.exports = functions.handler.firestore.document
               .import(currentDocumentsBatch);
           functions.logger.info(`Imported ${currentDocumentNumber} documents into Typesense`);
         } catch (error) {
-          functions.logger.error("Import error", erro);
+          functions.logger.error("Import error", error);
         }
       }
 

--- a/functions/src/backfillToTypesenseFromFirestore.js
+++ b/functions/src/backfillToTypesenseFromFirestore.js
@@ -21,21 +21,21 @@ const validateBackfillRun = (snapshot) => {
 module.exports = functions.handler.firestore.document
     .onWrite(async (snapshot, context) => {
       functions.logger.info("Backfilling " +
-        `${config.firestoreCollectionFields.join(",")} fields in Firestore documents ` +
-        `from ${config.firestoreCollectionPath} ` +
-        `into Typesense Collection ${config.typesenseCollectionName} ` +
-        `on ${config.typesenseHosts.join(",")}`);
+      `${config.firestoreCollectionFields.join(",")} fields in Firestore documents ` +
+      `from ${config.firestoreCollectionPath} ` +
+      `into Typesense Collection ${config.typesenseCollectionName} ` +
+      `on ${config.typesenseHosts.join(",")}`);
 
       if (!validateBackfillRun(snapshot)) {
         return false;
       }
 
       const querySnapshot =
-        await admin.firestore().collection(config.firestoreCollectionPath).get();
+      await admin.firestore().collection(config.firestoreCollectionPath).get();
       let currentDocumentNumber = 0;
       let currentDocumentsBatch = [];
       querySnapshot.forEach(async (firestoreDocument) => {
-        currentDocumentNumber+=1;
+        currentDocumentNumber += 1;
         currentDocumentsBatch.push(utils.typesenseDocumentFromSnapshot(firestoreDocument));
 
         if (currentDocumentNumber === config.typesenseBackfillBatchSize) {
@@ -47,8 +47,7 @@ module.exports = functions.handler.firestore.document
             currentDocumentsBatch = [];
             functions.logger.info(`Imported ${currentDocumentNumber} documents into Typesense`);
           } catch (error) {
-            functions.logger.error("Import error");
-            console.dir(error.importResults);
+            functions.logger.error("Import error", error);
           }
         }
       });
@@ -60,8 +59,7 @@ module.exports = functions.handler.firestore.document
               .import(currentDocumentsBatch);
           functions.logger.info(`Imported ${currentDocumentNumber} documents into Typesense`);
         } catch (error) {
-          functions.logger.error("Import error");
-          console.dir(error.importResults);
+          functions.logger.error("Import error", erro);
         }
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "firebase-typesense-search-extension",
       "devDependencies": {
         "dotenv": "^10.0.0",
         "eslint": "^7.27.0",


### PR DESCRIPTION
## Change Summary

* I combined the `functions.logger.error` and `console.dir` since `functions.logger.error` already has support for structured  logging
* I have changed the `error.importResults` to `error` to log. This is because, the `importResults` is `undefined` on errors.   can't find why my executions are failing

![image](https://user-images.githubusercontent.com/23056537/142719900-3e607435-8735-4cfa-8596-fd4b9c26b95a.png)

* Ran `npx eslint . --fix` to format


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
