### PR TITLE
Maping Firestore data types to Typesense data types

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -18,6 +18,7 @@
     "@babel/runtime": "^7.14.0",
     "firebase-admin": "^9.9.0",
     "firebase-functions": "^3.14.1",
+    "flat": "^5.0.2",
     "typesense": "^1.2.1"
   },
   "devDependencies": {

--- a/functions/src/utils.js
+++ b/functions/src/utils.js
@@ -20,8 +20,15 @@ exports.typesenseDocumentFromSnapshot = (
 
   const typesenseDocument = Object.fromEntries(
       entries.map(([key, value]) => {
-        const isGeoPoint = value instanceof admin.firestore.GeoPoint;
-        return [key, isGeoPoint ? [value.latitude, value.longitude] : value];
+        let typesenseValue = value;
+
+        if (value instanceof admin.firestore.Timestamp) {
+          typesenseValue = Math.floor(value.toDate().getTime() / 1000);
+        } else if (value instanceof admin.firestore.GeoPoint) {
+          typesenseValue = [value.latitude, value.longitude];
+        }
+
+        return [key, typesenseValue];
       }),
   );
   typesenseDocument.id = firestoreDocumentSnapshot.id;

--- a/test-params.local.env
+++ b/test-params.local.env
@@ -1,6 +1,6 @@
 LOCATION=us-central1
 FIRESTORE_COLLECTION_PATH=books
-FIRESTORE_COLLECTION_FIELDS=author,title
+FIRESTORE_COLLECTION_FIELDS=author,title,rating,isAvailable,location,createdAt,nested_field,tags,nullField,ref
 TYPESENSE_HOSTS=localhost
 TYPESENSE_PORT=8108
 TYPESENSE_PROTOCOL=http

--- a/test/indexToTypesenseOnFirestoreWrite.spec.js
+++ b/test/indexToTypesenseOnFirestoreWrite.spec.js
@@ -11,86 +11,508 @@ const firestore = app.firestore();
 
 describe("indexToTypesenseOnFirestoreWrite", () => {
   beforeEach(async () => {
-    // Clear the database between tests
+    // delete the Firestore collection
     await firestore.recursiveDelete(firestore.collection(config.firestoreCollectionPath));
 
-    // Clear any previously created collections
+    // delete the Typesense collection
     try {
       await typesense.collections(encodeURIComponent(config.typesenseCollectionName)).delete();
     } catch (e) {
       console.info(`${config.typesenseCollectionName} collection not found, proceeding...`);
     }
 
-    // Create a new Typesense collection
-    return typesense.collections().create({
+    // recreate the Typesense collection
+    await typesense.collections().create({
       name: config.typesenseCollectionName,
-      fields: [
-        {"name": ".*", "type": "auto"},
-      ],
+      fields: [{name: ".*", type: "auto"}],
     });
   });
 
   afterAll(async () => {
-    // clean up the firebase app after all tests have run
+    // clean up the whole firebase app
     await app.delete();
   });
 
-  it("indexes to Typesense on writes to specified Firestore collection", async () => {
-    const book = {
-      author: "Author A",
-      title: "Title X",
-      country: "USA",
-    };
+  it("indexes string values on writes to specified Firestore collection", async () => {
+    const docData = {author: "test"};
 
-    // Creation
-    const firestoreDoc = await firestore.collection(config.firestoreCollectionPath).add(book);
-    // Wait for firestore cloud function to write to Typesense
-    await new Promise((r) => setTimeout(r, 2000));
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
 
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
     let typesenseDocsStr = await typesense
         .collections(encodeURIComponent(config.typesenseCollectionName))
         .documents()
         .export();
     let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
     expect(typesenseDocs.length).toBe(1);
-    expect(typesenseDocs[0]).toStrictEqual({
-      id: firestoreDoc.id,
-      author: book.author,
-      title: book.title,
-    });
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, author: docData.author});
 
-    // Updates
-    book.title = "Title Y";
-    await firestore
-        .collection(config.firestoreCollectionPath)
-        .doc(firestoreDoc.id)
-        .set(book);
-    // Wait for firestore cloud function to write to Typesense
-    await new Promise((r) => setTimeout(r, 2000));
+    // update document in Firestore
+    docData.author = "test2";
 
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
     typesenseDocsStr = await typesense
         .collections(encodeURIComponent(config.typesenseCollectionName))
         .documents()
         .export();
     typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, author: docData.author});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes number values on writes to specified Firestore collection", async () => {
+    const docData = {rating: 22};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, rating: docData.rating});
+
+    // update document in Firestore
+    docData.rating = 43;
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, rating: docData.rating});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes boolean values on writes to specified Firestore collection", async () => {
+    const docData = {isAvailable: true};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, isAvailable: docData.isAvailable});
+
+    // update document in Firestore
+    docData.isAvailable = false;
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id, isAvailable: docData.isAvailable});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes map values on writes to specified Firestore collection", async () => {
+    const docData = {
+      nested_field: {
+        field1: "value1",
+        field2: ["value2", "value3", "value4"],
+        field3: {
+          fieldA: "valueA",
+          fieldB: ["valueB", "valueC", "valueD"],
+        },
+      },
+    };
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
     expect(typesenseDocs.length).toBe(1);
     expect(typesenseDocs[0]).toStrictEqual({
-      id: firestoreDoc.id,
-      author: book.author,
-      title: book.title,
+      "id": docRef.id,
+      "nested_field.field1": "value1",
+      "nested_field.field2": ["value2", "value3", "value4"],
+      "nested_field.field3.fieldA": "valueA",
+      "nested_field.field3.fieldB": ["valueB", "valueC", "valueD"],
     });
 
-    // Deletes
-    await firestore
-        .collection(config.firestoreCollectionPath)
-        .doc(firestoreDoc.id)
-        .delete();
-    // Wait for firestore cloud function to write to Typesense
-    await new Promise((r) => setTimeout(r, 2000));
+    // update document in Firestore
+    docData.nested_field.field1 = "new value1";
 
-    const typesenseCollection = await typesense
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
         .collections(encodeURIComponent(config.typesenseCollectionName))
-        .retrieve();
-    expect(typesenseCollection.num_documents).toBe(0);
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({
+      "id": docRef.id,
+      "nested_field.field1": "new value1",
+      "nested_field.field2": ["value2", "value3", "value4"],
+      "nested_field.field3.fieldA": "valueA",
+      "nested_field.field3.fieldB": ["valueB", "valueC", "valueD"],
+    });
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes array values on writes to specified Firestore collection", async () => {
+    const docData = {tags: ["tag1", "tag2", "tag3"]};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({"id": docRef.id, "tags": docData.tags});
+
+    // update document in Firestore
+    docData.tags = ["tag1", "tag2", "tag3", "tag4"];
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({"id": docRef.id, "tags": docData.tags});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes null values on writes to specified Firestore collection", async () => {
+    const docData = {nullField: null};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    const typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({"id": docRef.id});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes timestamp values on writes to specified Firestore collection", async () => {
+    const docData = {createdAt: new Date()};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({
+      id: docRef.id,
+      createdAt: Math.floor(docData.createdAt.getTime() / 1000),
+    });
+
+    // update document in Firestore
+    docData.createdAt = new Date(docData.createdAt.getTime() + 1000);
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({
+      id: docRef.id,
+      createdAt: Math.floor(docData.createdAt.getTime() / 1000),
+    });
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("indexes geo point values on writes to specified Firestore collection", async () => {
+    const docData = {location: new firebase.firestore.GeoPoint(0, 0)};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({
+      id: docRef.id,
+      location: [docData.location.latitude, docData.location.longitude],
+    });
+
+    // update document in Firestore
+    docData.location = new firebase.firestore.GeoPoint(1, 1);
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({
+      id: docRef.id,
+      location: [docData.location.latitude, docData.location.longitude],
+    });
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
+  });
+
+  it("ignores reference values on writes to specified Firestore collection", async () => {
+    const docData = {ref: firestore.doc("test/test")};
+
+    // create document in Firestore
+    const docRef = await firestore.collection(config.firestoreCollectionPath).add(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was indexed
+    let typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    let typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id});
+
+    // update document in Firestore
+    docData.ref = firestore.doc("test/test2");
+
+    await docRef.update(docData);
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was updated
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+    typesenseDocs = typesenseDocsStr.split("\n").map((s) => JSON.parse(s));
+
+    expect(typesenseDocs.length).toBe(1);
+    expect(typesenseDocs[0]).toStrictEqual({id: docRef.id});
+
+    // delete document in Firestore
+    await docRef.delete();
+
+    // wait for the Firestore cloud function to write to Typesense
+    await new Promise((r) => setTimeout(r, 2500));
+
+    // check that the document was deleted
+    typesenseDocsStr = await typesense
+        .collections(encodeURIComponent(config.typesenseCollectionName))
+        .documents()
+        .export();
+
+    expect(typesenseDocsStr).toBe("");
   });
 });


### PR DESCRIPTION
## Change Summary
Currently, if there is a GeoPoint value in your document you will receive this error log printed:

![Screen Shot 2022-04-14 at 12 02 52](https://user-images.githubusercontent.com/35961879/163351883-f29ce859-0db2-452b-bc1f-0292fef10f76.png)

- convert geo-point objects to a 2 element array
- convert timestamp dates to Unix timestamps

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
