### PR TITLE
Typesense port protocol params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.4.1
+
+- Added params to set typesense protocol and port
+
 ## Version 0.4.0
 
 - Sync ref.path to Typesense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Version 0.4.1
-
-- Added params to set typesense protocol and port
-
 ## Version 0.4.0
 
 - Sync ref.path to Typesense

--- a/extension.yaml
+++ b/extension.yaml
@@ -81,6 +81,20 @@ params:
       please be sure to mention all hostnames.
     example: xyz-1.a1.typesense.net,xyz-2.a1.typesense.net,xyz-3.a1.typesense.net
     required: true
+  - param: TYPESENSE_PORT
+    label: Typesense Port
+    description: >-
+      Typesense cluster Port
+    example: 8108
+    required: true
+    default: 443
+  - param: TYPESENSE_PROTOCOL
+    label: Typesense protocol
+    description: >-
+      Typesense cluster Protocol
+    example: http
+    default: https
+    required: true
   - param: TYPESENSE_API_KEY
     label: Typesense API Key
     type: secret


### PR DESCRIPTION
## Change Summary
If Typesense self hosted cluster is not running at 443 port, firestore will not sync changes
![image](https://user-images.githubusercontent.com/41275680/185773327-8b04c92e-df60-4dc0-8eac-3d1d4316daf9.png)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
