### PR TITLE
Fix backfill for subcollections

### DIFF
--- a/functions/src/backfillToTypesenseFromFirestore.js
+++ b/functions/src/backfillToTypesenseFromFirestore.js
@@ -40,8 +40,16 @@ module.exports = functions.handler.firestore.document
         return false;
       }
 
-      const querySnapshot =
-        await admin.firestore().collection(config.firestoreCollectionPath).get();
+      const isSubcollection = config.firestoreCollectionPath.includes("/");
+      let query;
+      if (isSubcollection) {
+        const collectionGroup = config.firestoreCollectionPath.split("/").pop();
+        query = admin.firestore().collectionGroup(collectionGroup);
+      } else {
+        query= admin.firestore().collection(config.firestoreCollectionPath);
+      }
+      const querySnapshot = await query.get();
+
       let currentDocumentNumber = 0;
       let currentDocumentsBatch = [];
       for (const firestoreDocument of querySnapshot.docs) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
With these changes, the backfill will now work also for subcollections, not only for "root" collection. If the collection path is something like `users/{userId}/items` the sync has already worked, but the backfill did not as the documents were queried with this collection path, but that did not work. Instead, we use the `collectionGroup` feature now with only the last part of the path.

Closes #17

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
