### PR TITLE
Fix/batch backfill

### DIFF
--- a/functions/src/backfillToTypesenseFromFirestore.js
+++ b/functions/src/backfillToTypesenseFromFirestore.js
@@ -11,7 +11,7 @@ admin.initializeApp({
 const validateBackfillRun = (snapshot) => {
   if (![true, "true"].includes(snapshot.after.get("trigger"))) {
     functions.logger.error(
-      "Skipping backfill. `trigger: true` key " +
+        "Skipping backfill. `trigger: true` key " +
       `was not found in Firestore document ${config.typesenseBackfillTriggerDocumentInFirestore}.`);
     return false;
   }
@@ -20,7 +20,7 @@ const validateBackfillRun = (snapshot) => {
   const collectionsToSync = snapshot.after.get("firestore_collections");
   if (Array.isArray(collectionsToSync) && !collectionsToSync.includes(config.firestoreCollectionPath)) {
     functions.logger.error(
-      "Skipping backfill. The `firestore_collections` key in " +
+        "Skipping backfill. The `firestore_collections` key in " +
       `${config.typesenseBackfillTriggerDocumentInFirestore} did not contain collection ${config.firestoreCollectionPath}.`);
     return false;
   }
@@ -29,60 +29,60 @@ const validateBackfillRun = (snapshot) => {
 };
 
 module.exports = functions.handler.firestore.document
-  .onWrite(async (snapshot, context) => {
-    functions.logger.info("Backfilling " +
+    .onWrite(async (snapshot, context) => {
+      functions.logger.info("Backfilling " +
       `${config.firestoreCollectionFields.join(",")} fields in Firestore documents ` +
       `from ${config.firestoreCollectionPath} ` +
       `into Typesense Collection ${config.typesenseCollectionName} ` +
       `on ${config.typesenseHosts.join(",")}`);
 
-    if (!validateBackfillRun(snapshot)) {
-      return false;
-    }
+      if (!validateBackfillRun(snapshot)) {
+        return false;
+      }
 
-    const querySnapshot =
+      const querySnapshot =
       await admin.firestore().collection(config.firestoreCollectionPath);
-    let lastDoc = null;
+      let lastDoc = null;
 
-    while (true) {
-      const queryFotThisBatch = lastDoc ? querySnapshot.startAfter(lastDoc) : querySnapshot;
-      const thisBatch = await queryFotThisBatch.limit(config.typesenseBackfillBatchSize).get();
-      if (thisBatch.empty) {
-        break;
-      }
-      const currentDocumentsBatch = thisBatch.docs;
-
-      lastDoc = thisBatch.docs.at(-1) ?? null;
-      try {
-        await typesense
-          .collections(encodeURIComponent(config.typesenseCollectionName))
-          .documents()
-          .import(currentDocumentsBatch);
-        functions.logger.info(`Imported ${currentDocumentsBatch.length} documents into Typesense`);
-      } catch (error) {
-        functions.logger.error(`Import error in a batch of documents from ${currentDocumentsBatch[0].id} to ${lastDoc.id}`, error);
-        if ("importResults" in error) {
-          logImportErrors(error.importResults);
+      do {
+        const queryFotThisBatch = lastDoc ? querySnapshot.startAfter(lastDoc) : querySnapshot;
+        const thisBatch = await queryFotThisBatch.limit(config.typesenseBackfillBatchSize).get();
+        if (thisBatch.empty) {
+          break;
         }
-      }
+        const currentDocumentsBatch = thisBatch.docs.map((doc) => utils.typesenseDocumentFromSnapshot(doc));
 
-      if (currentDocumentsBatch.length < config.typesenseBackfillBatchSize) {
-        break;
-      }
-      // Recurse on the next process tick, to avoid
-      // issues with the event loop on firebase functions related to resource release
-      await new Promise((resolve) => process.nextTick(resolve));
-    }
+        lastDoc = thisBatch.docs.at(-1) ?? null;
+        try {
+          await typesense
+              .collections(encodeURIComponent(config.typesenseCollectionName))
+              .documents()
+              .import(currentDocumentsBatch);
+          functions.logger.info(`Imported ${currentDocumentsBatch.length} documents into Typesense`);
+        } catch (error) {
+          functions.logger.error(`Import error in a batch of documents from ${currentDocumentsBatch[0].id} to ${lastDoc.id}`, error);
+          if ("importResults" in error) {
+            logImportErrors(error.importResults);
+          }
+        }
 
-    functions.logger.info("Done backfilling to Typesense from Firestore");
-  });
+        if (currentDocumentsBatch.length < config.typesenseBackfillBatchSize) {
+          break;
+        }
+        // Recurse on the next process tick, to avoid
+        // issues with the event loop on firebase functions related to resource release
+        await new Promise((resolve) => process.nextTick(resolve));
+      } while (lastDoc);
+
+      functions.logger.info("Done backfilling to Typesense from Firestore");
+    });
 
 function logImportErrors(importResults) {
   importResults.forEach((result) => {
     if (result.success) return;
 
     functions.logger.error(
-      `Error importing document with error: ${result.error}`,
-      result);
+        `Error importing document with error: ${result.error}`,
+        result);
   });
 }


### PR DESCRIPTION
## Change Summary
The current batch mechanism is failing on Firestore big collections with a function crash.
This PR fixing this issue.

Also on this PR -
Better comments for failing batch (the current one get trimmed when multiple errors)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
