### PR TITLE
feat(utils): implement nested field extraction

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,6 +10,7 @@
         "firebase-admin": "^12.2.0",
         "firebase-functions": "^5.0.1",
         "flat": "^6.0.1",
+        "lodash.get": "^4.4.2",
         "typesense": "^1.8.2"
       },
       "devDependencies": {
@@ -2267,6 +2268,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -5181,6 +5187,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,6 +19,7 @@
     "firebase-admin": "^12.2.0",
     "firebase-functions": "^5.0.1",
     "flat": "^6.0.1",
+    "lodash.get": "^4.4.2",
     "typesense": "^1.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# What is this?
This pull request enhances our Firestore to Typesense synchronization by adding support for nested field extraction. It allows users to specify nested fields using dot notation, making it easier to sync complex data structures from Firestore to Typesense.

# Rationale
This change resolves issue #90, which requests dot notation support for the "Firestore Collection Fields" parameter. By implementing this feature, we enable users to access any level property on fields they want to explicitly include in the trigger.

# Changes

## Added Features:
1. **New dependency in `functions/package.json`**:
   - Added `lodash.get` (version 4.4.2) for safe nested property access.

## Code Changes:
1. **In `functions/src/utils.js`**:
   - Imported `lodash.get` for nested field extraction.
   - Refactored `typesenseDocumentFromSnapshot` function to use `lodash.get` for accessing nested fields.
   - Updated field extraction logic to support dot notation for nested fields.

## Test Updates:
1. **In `test/utils.spec.js`**:
   - Added new test suite "Nested fields extraction" with four new test cases:
     - Extracting nested fields using dot notation
     - Handling missing nested fields gracefully
     - Extracting nested fields alongside top-level fields
     - Handling array indexing in dot notation

# Context
This change improves the flexibility of our Firestore to Typesense synchronization extension. Users can now easily map nested Firestore fields to Typesense, allowing for more complex data structures to be indexed and searched efficiently. This feature is particularly useful for projects with deeply nested document structures, enabling fine-grained control over which specific nested fields are synchronized to Typesense.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
