### PR TITLE
Move null filter in backfill to after await

### DIFF
--- a/functions/src/backfill.js
+++ b/functions/src/backfill.js
@@ -61,17 +61,20 @@ module.exports = functions.firestore.document(config.typesenseBackfillTriggerDoc
     if (thisBatch.empty) {
       break;
     }
-    const currentDocumentsBatch = await Promise.all(
-        thisBatch.docs.map(async (doc) => {
-          const docPath = doc.ref.path;
-          const pathParams = utils.pathMatchesSelector(docPath, config.firestoreCollectionPath);
+    const currentDocumentsBatch = (
+      await Promise.all(
+          thisBatch.docs.map(async (doc) => {
+            const docPath = doc.ref.path;
+            const pathParams = utils.pathMatchesSelector(docPath, config.firestoreCollectionPath);
 
-          if (!isGroupQuery || (isGroupQuery && pathParams !== null)) {
-            return await utils.typesenseDocumentFromSnapshot(doc, pathParams);
-          } else {
-            return null;
-          }
-        }).filter((doc) => doc !== null));
+            if (!isGroupQuery || (isGroupQuery && pathParams !== null)) {
+              return await utils.typesenseDocumentFromSnapshot(doc, pathParams);
+            } else {
+              return null;
+            }
+          }),
+      )
+    ).filter((doc) => doc !== null);
 
     lastDoc = thisBatch.docs.at(-1) ?? null;
     try {


### PR DESCRIPTION
## Change Summary
null filter was being applied to promises, and didn't actually work. 

Calling server with any "null" entries in the array didn't result in any problems, but did result in noisy innocuous errors "Bad JSON: not a properly formed document."

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
