### PR TITLE
fix(extension): remove attribute for db from event filters

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -30,8 +30,6 @@ resources:
         eventType: google.cloud.firestore.document.v1.written
         triggerRegion: ${LOCATION}
         eventFilters:
-          - attribute: database
-            value: (default)
           - attribute: document
             value: ${FIRESTORE_COLLECTION_PATH}/{documentID}
             operator: match-path-pattern
@@ -52,8 +50,6 @@ resources:
         eventType: google.cloud.firestore.document.v1.written
         triggerRegion: ${LOCATION}
         eventFilters:
-          - attribute: database
-            value: (default)
           - attribute: document
             value: typesense_sync/backfill
             operator: match-path-pattern


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes changes to the `extension.yaml` file to update the event filters for Firestore triggers. The most important changes include the removal of the `database` attribute filter.

Event filter updates:

* [`extension.yaml`](diffhunk://#diff-351708a19ffde8724e9fab88d33f20f75496ca2727448fcd0aac35c31a54a077L33-L34): Removed the `database` attribute filter from the event filters for document written events to simplify the configuration. [[1]](diffhunk://#diff-351708a19ffde8724e9fab88d33f20f75496ca2727448fcd0aac35c31a54a077L33-L34) [[2]](diffhunk://#diff-351708a19ffde8724e9fab88d33f20f75496ca2727448fcd0aac35c31a54a077L55-L56)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
