### PR TITLE
fix(extension): enclose default value for db in quotes

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -30,6 +30,8 @@ resources:
         eventType: google.cloud.firestore.document.v1.written
         triggerRegion: ${LOCATION}
         eventFilters:
+          - attribute: database
+            value: "(default)"
           - attribute: document
             value: ${FIRESTORE_COLLECTION_PATH}/{documentID}
             operator: match-path-pattern
@@ -50,6 +52,8 @@ resources:
         eventType: google.cloud.firestore.document.v1.written
         triggerRegion: ${LOCATION}
         eventFilters:
+          - attribute: database
+            value: "(default)"
           - attribute: document
             value: typesense_sync/backfill
             operator: match-path-pattern


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes changes to the `resources:` section in the `extension.yaml` file to add a new event filter attribute for the database.

Changes to `resources:` in `extension.yaml`:

* Added an event filter attribute for the database with the value "(default)" to the first `eventFilters` list.
* Added an event filter attribute for the database with the value "(default)" to the second `eventFilters` list.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
