### PR TITLE
feat(functions): add support for multi-region firestore databases

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -31,7 +31,7 @@ resources:
         triggerRegion: ${LOCATION}
         eventFilters:
           - attribute: database
-            value: "(default)"
+            value: projects/${param:PROJECT_ID}/databases/(default)/locations/${param:FIRESTORE_DATABASE_LOCATION}
           - attribute: document
             value: ${FIRESTORE_COLLECTION_PATH}/{documentID}
             operator: match-path-pattern
@@ -53,7 +53,7 @@ resources:
         triggerRegion: ${LOCATION}
         eventFilters:
           - attribute: database
-            value: "(default)"
+            value: projects/${param:PROJECT_ID}/databases/(default)/locations/${param:FIRESTORE_DATABASE_LOCATION}
           - attribute: document
             value: typesense_sync/backfill
             operator: match-path-pattern
@@ -121,6 +121,12 @@ params:
         value: true
     default: false
     required: false
+  - param: FIRESTORE_DATABASE_LOCATION
+    label: Firestore Database Location
+    description: >-
+      The location of your Firestore database (e.g., nam5 for North America, eur3 for Europe).
+      You can find this by running 'gcloud firestore databases list'.
+    required: true
   - param: LOG_TYPESENSE_INSERTS
     label: Log Typesense Inserts for Debugging
     description: >-


### PR DESCRIPTION

## Change Summary
- Add `FIRESTORE_DATABASE_LOCATION` parameter for users to specify their database location
- Update event filters to use full path format including database location
- Fix compatibility with databases in multi-region deployments (nam5, eur3, etc.)


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
