### PR TITLE
fix(extension): revert location changes

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -155,72 +155,22 @@ params:
         value: us-east1
       - label: Northern Virginia (us-east4)
         value: us-east4
-      - label: Columbus (us-east5)
-        value: us-east5
-      - label: Dallas (us-south1)
-        value: us-south1
-      - label: Oregon (us-west1)
-        value: us-west1
+      - label: Warsaw (europe-central2)
+        value: europe-central2
       - label: Los Angeles (us-west2)
         value: us-west2
       - label: Salt Lake City (us-west3)
         value: us-west3
       - label: Las Vegas (us-west4)
         value: us-west4
-      - label: Montréal (northamerica-northeast1)
-        value: northamerica-northeast1
-      - label: Toronto (northamerica-northeast2)
-        value: northamerica-northeast2
-      - label: Queretaro (northamerica-south1)
-        value: northamerica-south1
-      - label: North America (nam5)
-        value: nam5
-      - label: São Paulo (southamerica-east1)
-        value: southamerica-east1
-      - label: Santiago (southamerica-west1)
-        value: southamerica-west1
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)
         value: europe-west2
       - label: Frankfurt (europe-west3)
         value: europe-west3
-      - label: Netherlands (europe-west4)
-        value: europe-west4
       - label: Zurich (europe-west6)
         value: europe-west6
-      - label: Milan (europe-west8)
-        value: europe-west8
-      - label: Paris (europe-west9)
-        value: europe-west9
-      - label: Berlin (europe-west10)
-        value: europe-west10
-      - label: Turin (europe-west12)
-        value: europe-west12
-      - label: Madrid (europe-southwest1)
-        value: europe-southwest1
-      - label: Finland (europe-north1)
-        value: europe-north1
-      - label: Warsaw (europe-central2)
-        value: europe-central2
-      - label: Europe (eur3)
-        value: eur3
-      - label: Tel Aviv (me-west1)
-        value: me-west1
-      - label: Doha (me-central1)
-        value: me-central1
-      - label: Dammam (me-central2)
-        value: me-central2
-      - label: Mumbai (asia-south1)
-        value: asia-south1
-      - label: Delhi (asia-south2)
-        value: asia-south2
-      - label: Singapore (asia-southeast1)
-        value: asia-southeast1
-      - label: Jakarta (asia-southeast2)
-        value: asia-southeast2
-      - label: Taiwan (asia-east1)
-        value: asia-east1
       - label: Hong Kong (asia-east2)
         value: asia-east2
       - label: Tokyo (asia-northeast1)
@@ -229,12 +179,18 @@ params:
         value: asia-northeast2
       - label: Seoul (asia-northeast3)
         value: asia-northeast3
+      - label: Mumbai (asia-south1)
+        value: asia-south1
+      - label: Singapore (asia-southeast1)
+        value: asia-southeast1
+      - label: Jakarta (asia-southeast2)
+        value: asia-southeast2
+      - label: Montreal (northamerica-northeast1)
+        value: northamerica-northeast1
+      - label: Sao Paulo (southamerica-east1)
+        value: southamerica-east1
       - label: Sydney (australia-southeast1)
         value: australia-southeast1
-      - label: Melbourne (australia-southeast2)
-        value: australia-southeast2
-      - label: Johannesburg (africa-south1)
-        value: africa-south1
     default: us-central1
     required: true
     immutable: true


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes significant changes to the `extension.yaml` file, specifically in the `params:` section. The changes involve updating the list of available regions by removing several entries and adding new ones.

Changes to available regions:

* Removed regions including Columbus (us-east5), Dallas (us-south1), Oregon (us-west1), and many others.
* Added new regions such as Warsaw (europe-central2), Mumbai (asia-south1), Singapore (asia-southeast1), and others.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
