### PR TITLE
fix(backfill): correct variable name in error handler

### DIFF
--- a/functions/src/backfill.js
+++ b/functions/src/backfill.js
@@ -92,10 +92,10 @@ module.exports = onDocumentWritten("typesense_sync/backfill", async (snapshot, c
     try {
       await typesense.collections(encodeURIComponent(config.typesenseCollectionName)).documents().import(currentDocumentsBatch, {action: "upsert"});
       info(`Imported ${currentDocumentsBatch.length} documents into Typesense`);
-    } catch (error) {
-      error(`Import error in a batch of documents from ${currentDocumentsBatch[0].id} to ${lastDoc.id}`, error);
-      if ("importResults" in error) {
-        logImportErrors(error.importResults);
+    } catch (err) {
+      error(`Import error in a batch of documents from ${currentDocumentsBatch[0].id} to ${lastDoc.id}`, err);
+      if ("importResults" in err) {
+        logImportErrors(err.importResults);
       }
     }
 


### PR DESCRIPTION
### TLDR
Fixed naming conflict between 'error' variable and error logging function in catch block.

## Change Summary
#### Code Changes:
1. **In `functions/src/backfill.js`**:
   - Renamed `error` variable to `err` in catch block (line 95) to avoid collision with the error logging function
   - Updated subsequent references to use `err` instead of `error` (lines 96-98)

### Context
- The backfill function was using the same name (`error`) for both the caught exception variable and the error logging function, which could lead to confusion and potential issues
- This fix ensures proper error handling and logging in the Typesense document import process


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
