### PR TITLE
fix(backfill): return the id of the failed document on backfill errors

### DIFF
--- a/functions/src/backfill.js
+++ b/functions/src/backfill.js
@@ -90,7 +90,7 @@ module.exports = onDocumentWritten("typesense_sync/backfill", async (snapshot, c
 
     lastDoc = thisBatch.docs.at(-1) ?? null;
     try {
-      await typesense.collections(encodeURIComponent(config.typesenseCollectionName)).documents().import(currentDocumentsBatch, {action: "upsert"});
+      await typesense.collections(encodeURIComponent(config.typesenseCollectionName)).documents().import(currentDocumentsBatch, {action: "upsert", return_id: true});
       info(`Imported ${currentDocumentsBatch.length} documents into Typesense`);
     } catch (err) {
       error(`Import error in a batch of documents from ${currentDocumentsBatch[0].id} to ${lastDoc.id}`, err);


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Add the `return_id: true` option to the `import` method of the Typesense collection to ensure that document IDs are returned upon import failure.

* [`functions/src/backfill.js`](diffhunk://#diff-7b6c256d270d8a6045535d7d1eb08df7a1a5f6e266296c42a5e983500b6648aaL93-R93): Added the `return_id: true` option to the `import` method of the Typesense collection to ensure document IDs are returned upon import.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
