### PR TITLE
Add document transformation capability for indexing

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -349,3 +349,39 @@ params:
         value: true
     default: false
     required: false
+  - param: TRANSFORM_FUNCTION_NAME
+    label: Transform Function Name
+    description: >-
+      Optional: Name of a Cloud Function to transform Firestore documents before indexing them into Typesense.
+      If specified, this extension will call this function with each document before indexing.
+      Leave empty to skip transformation.
+    example: transformDoc
+    default: ""
+    required: false
+  - param: TRANSFORM_FUNCTION_PROJECT_ID
+    label: Transform Function Project ID
+    description: >-
+      Project ID where the transform function is deployed. 
+      Only required if TRANSFORM_FUNCTION_NAME is set.
+      Defaults to the current project ID if not specified.
+    example: my-project
+    default: ""
+    required: false
+  - param: TRANSFORM_FUNCTION_REGION
+    label: Transform Function Region
+    description: >-
+      Region where the transform function is deployed.
+      Only required if TRANSFORM_FUNCTION_NAME is set.
+      Defaults to the same region as this extension if not specified.
+    example: us-central1
+    default: ""
+    required: false
+  - param: TRANSFORM_FUNCTION_SECRET
+    label: Transform Function Secret
+    type: secret
+    description: >-
+      Authorization secret for the transform function.
+      This will be sent in the Authorization header as "Bearer [secret]".
+      Only required if TRANSFORM_FUNCTION_NAME is set and the transform function requires authorization.
+    example: ""
+    required: false

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -13,4 +13,8 @@ module.exports = {
   typesenseAPIKey: process.env.TYPESENSE_API_KEY,
   typesenseBackfillTriggerDocumentInFirestore: "typesense_sync/backfill",
   typesenseBackfillBatchSize: 1000,
+  transformFunctionName: process.env.TRANSFORM_FUNCTION_NAME,
+  transformFunctionSecret: process.env.TRANSFORM_FUNCTION_SECRET,
+  transformFunctionProjectId: process.env.TRANSFORM_FUNCTION_PROJECT_ID || process.env.GCLOUD_PROJECT,
+  transformFunctionRegion: process.env.TRANSFORM_FUNCTION_REGION || process.env.REGION,
 };

--- a/functions/src/indexOnWrite.js
+++ b/functions/src/indexOnWrite.js
@@ -17,7 +17,13 @@ exports.indexOnWrite = onDocumentWritten(`${config.firestoreCollectionPath}/{doc
 
     // snapshot.after.ref.get() will refetch the latest version of the document
     const latestSnapshot = await snapshot.data.after.ref.get();
-    const typesenseDocument = await utils.typesenseDocumentFromSnapshot(latestSnapshot, snapshot.params);
+    let typesenseDocument;
+    if (config.transformFunctionName) {
+      const transformedDocument = await utils.transformDocument(latestSnapshot);
+      typesenseDocument = await utils.typesenseDocumentFromSnapshot(transformedDocument, snapshot.params);
+    } else {
+      typesenseDocument = await utils.typesenseDocumentFromSnapshot(latestSnapshot, snapshot.params);
+    }
 
     if (config.shouldLogTypesenseInserts) {
       debug(`Upserting document ${JSON.stringify(typesenseDocument)}`);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:flatttened": "cp -f extensions/test-params-flatten-nested-true.local.env functions/.env && cross-env NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG=extensions/test-params-flatten-nested-true.local.env firebase emulators:exec --only functions,firestore,extensions  'jest --testRegex=\"WithFlattening\" --testRegex=\"backfill.spec\"'",
     "test:unflattened": "cp -f extensions/test-params-flatten-nested-false.local.env functions/.env && cross-env NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG=extensions/test-params-flatten-nested-false.local.env firebase emulators:exec --only functions,firestore,extensions 'jest --testRegex=\"WithoutFlattening\"'",
     "test:subcollection": "jest --testRegex=\"writeLogging\" --testRegex=\"Subcollection\" --detectOpenHandles",
+    "test:utils": "jest --testRegex=\"utilsTransform\"",
     "typesenseServer": "docker compose up",
     "lint:fix": "eslint . --fix",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "emulator": "cross-env DOTENV_CONFIG=extensions/test-params-flatten-nested-false.local.env firebase emulators:start --import=emulator_data",
     "export": "firebase emulators:export emulator_data",
-    "test": "npm run test:flatttened && npm run test:unflattened && npm run test:subcollection",
+    "test": "npm run test:flatttened && npm run test:unflattened && npm run test:subcollection && npm run test:utils",
     "test:flatttened": "cp -f extensions/test-params-flatten-nested-true.local.env functions/.env && cross-env NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG=extensions/test-params-flatten-nested-true.local.env firebase emulators:exec --only functions,firestore,extensions  'jest --testRegex=\"WithFlattening\" --testRegex=\"backfill.spec\"'",
     "test:unflattened": "cp -f extensions/test-params-flatten-nested-false.local.env functions/.env && cross-env NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG=extensions/test-params-flatten-nested-false.local.env firebase emulators:exec --only functions,firestore,extensions 'jest --testRegex=\"WithoutFlattening\"'",
     "test:subcollection": "jest --testRegex=\"writeLogging\" --testRegex=\"Subcollection\" --detectOpenHandles",

--- a/test/utilsTransform.spec.js
+++ b/test/utilsTransform.spec.js
@@ -1,0 +1,149 @@
+const {TestEnvironment} = require("./support/testEnvironment");
+
+const mockFetch = jest.fn();
+global.fetch = (...args) => mockFetch(...args);
+
+describe("Utils - transformDocument", () => {
+  let testEnvironment;
+  let utils;
+  let config;
+
+  beforeAll((done) => {
+    testEnvironment = new TestEnvironment({
+      dotenvConfig: `
+LOCATION=us-central1
+FIRESTORE_DATABASE_REGION=nam5
+FIRESTORE_COLLECTION_PATH=books
+FIRESTORE_COLLECTION_FIELDS=author,title
+TYPESENSE_HOSTS=localhost
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=http
+TYPESENSE_COLLECTION_NAME=books_firestore
+TYPESENSE_API_KEY=xyz
+TRANSFORM_FUNCTION_NAME=
+TRANSFORM_FUNCTION_SECRET=test-secret
+TRANSFORM_FUNCTION_PROJECT_ID=test-project
+TRANSFORM_FUNCTION_REGION=us-central1
+`,
+    });
+
+    testEnvironment.setupTestEnvironment(done);
+  });
+
+  beforeEach(() => {
+    utils = require("../functions/src/utils.js");
+    config = require("../functions/src/config.js");
+
+    mockFetch.mockReset();
+
+    testEnvironment.resetCapturedEmulatorLogs();
+  });
+
+  afterAll(async () => {
+    await testEnvironment.teardownTestEnvironment();
+  });
+
+  describe("when no transform function is defined", () => {
+    it("returns the original document and logs an error", async () => {
+      config.transformFunctionName = null;
+
+      const document = {id: "123", title: "Test Document"};
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(document);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      expect(testEnvironment.capturedEmulatorLogs).toContain("No transform function defined. Returning original document.");
+    });
+  });
+
+  describe("when transform function is defined", () => {
+    beforeEach(() => {
+      config.transformFunctionName = "test-transform-function";
+    });
+
+    it("successfully transforms a document", async () => {
+      const document = {id: "123", title: "Test Document"};
+      const transformedDocument = {id: "123", title: "Transformed Document"};
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => transformedDocument,
+      });
+
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(transformedDocument);
+
+      expect(mockFetch).toHaveBeenCalledWith("https://us-central1-test-project.cloudfunctions.net/test-transform-function", {
+        method: "POST",
+        body: JSON.stringify({document}),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-secret",
+        },
+      });
+
+      expect(testEnvironment.capturedEmulatorLogs).toContain("Calling transform function: test-transform-function");
+      expect(testEnvironment.capturedEmulatorLogs).toContain("Transform function succeeded for document 123");
+    });
+
+    it("returns original document when transform function returns null/undefined", async () => {
+      const document = {id: "123", title: "Test Document"};
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => null,
+      });
+
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(document);
+
+      expect(testEnvironment.capturedEmulatorLogs).toContain("Transform function failed for document 123. Using original document.");
+    });
+
+    it("returns original document when fetch response is not OK", async () => {
+      const document = {id: "123", title: "Test Document"};
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: "Internal Server Error",
+      });
+
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(document);
+
+    });
+
+    it("returns original document when fetch throws an exception", async () => {
+      const document = {id: "123", title: "Test Document"};
+
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(document);
+
+      expect(testEnvironment.capturedEmulatorLogs).toContain("Error calling transform function: Network error");
+    });
+
+    it("handles documents without an ID properly", async () => {
+      const document = {title: "Test Document Without ID"};
+      const transformedDocument = {title: "Transformed Document"};
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => transformedDocument,
+      });
+
+      const result = await utils.transformDocument(document);
+
+      expect(result).toEqual(transformedDocument);
+
+      expect(testEnvironment.capturedEmulatorLogs).toContain("Transform function succeeded for document unknown");
+    });
+  });
+});


### PR DESCRIPTION
### TLDR
New options to transform Firestore documents before indexing to Typesense.

## Change Summary

#### Added Configuration:
1. **In `extension.yaml`**:
   - Added 4 new configuration parameters:
     - `TRANSFORM_FUNCTION_NAME`: Name of Cloud Function for document transformation
     - `TRANSFORM_FUNCTION_PROJECT_ID`: Project where transform function is deployed
     - `TRANSFORM_FUNCTION_REGION`: Region of transform function
     - `TRANSFORM_FUNCTION_SECRET`: Auth secret for transform function

#### Added Functionality:
1. **In `utils.js`**:
   - Added `transformDocument()`: Calls external transform function with error handling
   - Implements fallback to original document when transformation fails

2. **In `indexOnWrite.js`**:
   - Updated to conditionally use document transformation before indexing
   - Added branch to handle transformed vs. non-transformed document flow

#### Added Tests:
1. **New file `test/utilsTransform.spec.js`**:
   - Tests for transform function with various scenarios:
     - Success path with proper transformation
     - Handling missing transform function configuration
     - Error handling for failed transformations
     - Edge cases like documents without IDs

2. **In `package.json`**:
   - Added new test command: `test:utils`


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
