### PR TITLE
Configurable retry params

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typesense:
-    image: typesense/typesense:27.0
+    image: typesense/typesense:29.0
     restart: on-failure
     ports:
       - "8108:8108"

--- a/extension.yaml
+++ b/extension.yaml
@@ -348,3 +348,19 @@ params:
         value: true
     default: false
     required: false
+  - param: TYPESENSE_CONNECTION_TIMEOUT_SECONDS
+    label: Typesense Connection Timeout (seconds)
+    description: >-
+      The timeout in seconds for connections to Typesense. This applies to both connection timeout.
+    type: string
+    example: "60"
+    default: "60"
+    required: false
+  - param: TYPESENSE_RETRY_INTERVAL_SECONDS
+    label: Typesense Retry Interval (seconds)
+    description: >-
+      The retry interval in seconds for connections to Typesense. This applies to both connection timeout.
+    type: string
+    example: "60"
+    default: "60"
+    required: false

--- a/functions/src/config.js
+++ b/functions/src/config.js
@@ -11,6 +11,8 @@ module.exports = {
   typesenseProtocol: process.env.TYPESENSE_PROTOCOL || "https",
   typesenseCollectionName: process.env.TYPESENSE_COLLECTION_NAME,
   typesenseAPIKey: process.env.TYPESENSE_API_KEY,
+  typesenseConnectionTimeoutSeconds: parseInt(process.env.TYPESENSE_CONNECTION_TIMEOUT_SECONDS || "60", 10),
+  typesenseRetryIntervalSeconds: parseInt(process.env.TYPESENSE_RETRY_INTERVAL_SECONDS || "60", 10),
   typesenseBackfillTriggerDocumentInFirestore: "typesense_sync/backfill",
   typesenseBackfillBatchSize: 1000,
 };

--- a/functions/src/createTypesenseClient.js
+++ b/functions/src/createTypesenseClient.js
@@ -1,11 +1,6 @@
 const config = require("./config.js");
 const Typesense = require("typesense");
 
-// eslint-disable-next-line require-jsdoc
-function getRandomNumber(min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
 module.exports = function () {
   return new Typesense.Client({
     nodes: config.typesenseHosts.map((h) => {
@@ -16,7 +11,7 @@ module.exports = function () {
       };
     }),
     apiKey: config.typesenseAPIKey,
-    connectionTimeoutSeconds: getRandomNumber(60, 90),
-    retryIntervalSeconds: getRandomNumber(60, 120),
+    connectionTimeoutSeconds: config.typesenseConnectionTimeoutSeconds,
+    retryIntervalSeconds: config.typesenseRetryIntervalSeconds,
   });
 };


### PR DESCRIPTION
## Change Summary
Add the ability to reconfigure retry parameters from a random integer between 60 and 120 seconds respectively to an arbitrary value.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
