### PR TITLE
BUGFIX: Firestore query should have `orderBy` to ensure correct pagination

### DIFF
--- a/functions/src/backfill.js
+++ b/functions/src/backfill.js
@@ -60,6 +60,7 @@ module.exports = onDocumentWritten("typesense_sync/backfill", async (snapshot, c
   } else {
     querySnapshot = admin.firestore().collection(config.firestoreCollectionPath);
   }
+  querySnapshot = querySnapshot.orderBy(admin.firestore.FieldPath.documentId(), "asc");
 
   let lastDoc = null;
 


### PR DESCRIPTION
## Summary

Current backfill script does not scan all documents and may miss some documents. This is not well documented by [Firebase SDK documentation](https://firebase.google.com/docs/firestore/query-data/query-cursors), but as it can be seen from all examples, an `orderBy` is required to ensure all documents are reliably scanned through when pagination (i.e. `startAfter` or `startAt`) is used. Without it, the behavior is not deterministic.

This PR adds a `orderBy(documentId(), "asc")` to the backfill query as all collections have this native field and is not collection dependent.

## Test plan

I deployed the modified extension and confirmed that it's running.