### PR TITLE
fix(build): change flatten nested docs type from select to str

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -366,14 +366,10 @@ params:
     description: >-
       Comma-separated list of boolean values indicating whether to flatten nested documents for each collection.
       Each value corresponds to a collection in FIRESTORE_COLLECTION_PATHS.
-    type: select
-    options:
-      - label: No
-        value: false
-      - label: Yes
-        value: true
+    validationRegex: "^$|^(true|false)(,(true|false))*$"
+    validationErrorMessage: Flatten Nested Documents List must be empty or a comma-separated list of true/false values.
     example: false,true,false,true
-    default: false,true
+    default: ""
     required: false
 
   - param: TYPESENSE_HOSTS


### PR DESCRIPTION
## Change Summary
- there need to be comma-separated values for booleans here


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
