### PR TITLE
docs: mention backfill timeout for large collections

### DIFF
--- a/POSTINSTALL.md
+++ b/POSTINSTALL.md
@@ -27,6 +27,8 @@ In order to backfill data that already exists in your Firestore collection to yo
 
 This will trigger the backfill background function, which will read data from your Firestore collection and create equivalent documents in your Typesense collection.
 
+**Note on large collections:** The `backfill` function is deployed with the Cloud Functions default timeout of 540 seconds (9 minutes). If you're backfilling a large collection (e.g. hundreds of thousands of documents or more) and the function times out before finishing, you can increase the timeout up to 3600 seconds (1 hour) from the Google Cloud Console by editing the `backfill` Cloud Run service and bumping the request timeout.
+
 ### See the Extension in Action
 
 Try adding or updating a Firestore document in your configured Firestore collection through the Firestore UI.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ This extension only syncs data that was created or changed in Firestore, after i
 
 This will trigger the backfill background Cloud function, which will read data from your Firestore collection(s) and create equivalent documents in your Typesense collection.
 
+> [!NOTE]
+> The `backfill` function is deployed with the Cloud Functions default timeout of 540 seconds (9 minutes). If you're backfilling a large collection (e.g. hundreds of thousands of documents or more) and the function times out before finishing, you can increase the timeout up to 3600 seconds (1 hour) from the Google Cloud Console by editing the `backfill` Cloud Run service and bumping the request timeout.
+
 ## ☁️ Cloud Functions
 
 * **indexOnWrite:** A function that indexes data into Typesense when it's triggered by Firestore changes.


### PR DESCRIPTION
## Change Summary
Add a note on postinstall and general readme outlining the default value for backfill run timeouts

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
